### PR TITLE
Update Dockerfile to fix Amass error

### DIFF
--- a/Docker/pyreconer/Dockerfile
+++ b/Docker/pyreconer/Dockerfile
@@ -4,7 +4,7 @@ RUN mkdir PyReconer
 COPY PyReconer.py /PyReconer
 WORKDIR /PyReconer
 RUN mkdir output
-RUN wget https://github.com/OWASP/Amass/releases/download/3.0.4/amass_3.0.4_linux_amd64.zip && unzip amass_3.0.4_linux_amd64.zip && mv amass_3.0.4_linux_amd64 amass
+RUN wget https://github.com/OWASP/Amass/releases/download/v3.4.4/amass_v3.4.4_linux_amd64.zip && unzip amass_v3.4.4_linux_amd64.zip && mv amass_v3.4.4_linux_amd64 amass
 RUN wget https://github.com/michenriksen/aquatone/releases/download/v1.7.0/aquatone_linux_amd64_1.7.0.zip && unzip aquatone_linux_amd64_1.7.0.zip -d aquatone
 RUN wget https://download-chromium.appspot.com/dl/Linux_x64?type=snapshots -O chrome-linux.zip && unzip chrome-linux.zip
 RUN apt update && apt -y install nmap


### PR DESCRIPTION
amass_3.0.4 is trying to download  wordlist file alterations.txt but the file is no longer in the directory
When ran, you get an error like this:
Failed to obtain the wordlist at https://raw.githubusercontent.com/OWASP/Amass/master/wordlists/alterations.txt: 404 Not Found
I've updated the Dockerfile to download a newer version  (amass_v3.4.4) which doesn't have this issue.